### PR TITLE
fix: (Vercel)run alembic upgrade head in lifespan instead of raw ALTER TABLE

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,22 +1,22 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy import text
 
 from app.api.routers import router as api_router
 from app.core.config import get_cors_origins
 from app.core.logging import setup_logging
-from app.db.session import engine
 
 setup_logging()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Idempotent schema migration — adds channel column if it doesn't exist yet
-    with engine.connect() as conn:
-        conn.execute(text("ALTER TABLE results ADD COLUMN IF NOT EXISTS channel TEXT"))
-        conn.commit()
+    # Run all pending Alembic migrations on startup (idempotent)
+    from alembic.config import Config
+    from alembic import command
+    import os
+    alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
+    command.upgrade(alembic_cfg, "head")
     yield
 
 


### PR DESCRIPTION
The production DB on Vercel was empty (no tables at all). The previous lifespan tried to ALTER TABLE results which failed because the table didn't exist yet. Running alembic upgrade head on startup is idempotent and handles both fresh DB provisioning and incremental migrations.